### PR TITLE
update to v0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/config/config.nut

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Zombie Fortress Classic
-*Version:* Pre-alpha v0.2.0
+*Version:* Pre-alpha v0.3.0
 
 This VScript mod aims to be a faithful reimplementation of the Zombie Fortress mode made originally with [SourceMod](https://forums.alliedmods.net/showthread.php?t=77762) for Team Fortress 2.
 

--- a/config/config.example.nut
+++ b/config/config.example.nut
@@ -1,0 +1,23 @@
+// User configuration file
+//
+// Instructions:
+// - Rename this file to "config.nut" to use it
+// - Remove the // comments for values where you want to change the defaults.
+//
+// If it's loaded successfully, the server logs will say "[ZF] Loaded user configuration"
+::SW_ZF_LoadUserConfig <- function(reserved) {
+    return {
+        // Do not modify this, this is the config file format version.
+        // This will allow us to support old config files if this structure gets updated.
+        config_version = "1",
+
+        // force_enabled will enable zombie fortress for all maps, not just zombie maps.
+        // Default: false
+        // force_enabled = false,
+
+        // survivor_team_ratio will make the survivor team have 65% of the player, and zombies
+        // will have 35%.
+        // Default: 0.65
+        // survivor_team_ratio = 0.65,
+    }
+}

--- a/src/confsys.nut
+++ b/src/confsys.nut
@@ -1,0 +1,110 @@
+// zf_config contains the configuration for the game mode
+zf_config <- {};
+
+::SW_ZF_UserConfigLoad <- function(zf_default_config) {
+	local has_user_config = false;
+	try {
+		IncludeScript("sw_zombie_fortress/config/config.nut");
+		has_user_config = true;
+	} catch (e) {
+		// Handle script doesn't exist case
+		if (startswith(e, "Failed to include script")) {
+			// fallthrough to "user configuration not found"
+		} else {
+			printl("[ZF] Error importing user configuration: " + e);
+			throw e;
+		}
+	}
+	if (!has_user_config) {
+		return;
+	}
+	local user_config = null;
+	try {
+		// note(jae): 2023-08-13
+		// Might pass in helper variables into this later such as
+		// - Is current map ZF supported.
+		// - The default config loaded.
+		local reserved = {};
+		user_config = SW_ZF_LoadUserConfig(reserved);
+	} catch (e) {
+		printl("[ZF] A scripting error occurred trying to load user config: " + e);
+		throw e;
+	}
+	if (typeof user_config != "table") {
+		printl("[ZF] Invalid user config, expected table of values but got: " + typeof user_config);
+		return;
+	}
+
+	// Detect config version
+	if (!("config_version" in user_config)) {
+		printl("[ZF] Missing config_version in user configuration");
+		return;
+	}
+	local config_version = user_config["config_version"];
+	if (typeof config_version != "string") {
+		printl("[ZF] Expected config version to be string");
+		return;
+	}
+	if (config_version != "1") {
+		printl("[ZF] Expected config version to equal \"1\", that's the only valid version right now");
+		return;
+	}
+	delete user_config["config_version"];
+
+	// Copy default config
+	local merge_user_and_default_zf_config = {};
+	foreach (k, v in zf_default_config) {
+		merge_user_and_default_zf_config[k] <- v;
+	}
+	// Validate and apply user config to config
+	local isInvalid = false;
+	foreach (k, v in user_config) {
+		if (!(k in zf_default_config)) {
+			printl("[ZF] User config error: key \"" + k + "\" does not exist and is invalid");
+			isInvalid = true;
+			continue;
+		}
+		local actualType = typeof v;
+		local expectedType = typeof zf_default_config[k];
+		if (actualType != expectedType) {
+			printl("[ZF] User config error: key \"" + k + "\" is invalid type. Expected " + expectedType + " but got " + actualType);
+			isInvalid = true;
+			continue;
+		}
+		merge_user_and_default_zf_config[k] = v;
+	}
+	if (isInvalid) {
+		printl("[ZF] User configuration had errors. Not applying it");
+		return;
+	}
+	return merge_user_and_default_zf_config;
+}
+
+::SW_ZF_ConfigLoad <- function() {
+	// zf_default_config contains the configuration for the game mode
+	local zf_default_config = {
+		// config_version is the config format, this will allow us to be backwards compatible
+		// with old config file formats.
+		config_version = "1",
+		// force_enabled will enable zombie fortress for all maps, not just zombie maps
+		force_enabled = false,
+		// survivor_team_ratio will make the survivor team have 65% of the player, and zombies
+		// will have 35%.
+		survivor_team_ratio = 0.65,
+	};
+
+	// Load user config
+	local zf_user_config = null;
+	try {
+		zf_user_config = SW_ZF_UserConfigLoad(zf_default_config);
+	} catch (e) {
+		throw e;
+	}
+	if (typeof zf_user_config == "table") {
+		zf_config = zf_user_config;
+		printl("[ZF] Loaded user configuration");
+	} else {
+		zf_config = zf_default_config;
+		printl("[ZF] No valid user configuration found, using default settings");
+	}
+}

--- a/src/main.nut
+++ b/src/main.nut
@@ -1,0 +1,33 @@
+::SW_ZF_Main <- function() {
+	if (zf_hasInitialized) {
+		return;
+	}
+	IncludeScript("sw_zombie_fortress/src/confsys.nut");
+
+	// Get mapname and remove "workshop/" prefix if it exists
+	local mapname = GetMapName();
+	if (startswith(mapname, "workshop/")) {
+		mapname = mapname.slice("workshop/".len());
+	}
+
+	local is_zf_map = (
+		startswith(mapname, "zf_") ||
+		startswith(mapname, "zf2_") ||
+		// Support Zombie Escape maps (untested)
+		startswith(mapname, "ze_") ||
+		// Support Super Zombie Fortress maps (untested)
+		startswith(mapname, "szf_")
+	);
+
+	SW_ZF_ConfigLoad();
+
+	local is_zf_enabled = is_zf_map || zf_config.force_enabled;
+	if (!is_zf_enabled) {
+		printl("[ZF] Zombie Fortress mode is *not* enabled for this map")
+		return;
+	}
+
+	// Initialize game logic if enabled
+	IncludeScript("sw_zombie_fortress/src/gamemode.nut");
+	SW_ZF_Init(is_zf_map);
+}


### PR DESCRIPTION
- You can now configure your server with a few options by adding a "sw_zombie_fortress/config/config.nut" file. See the "config.example.nut" file.
- Game no longer defaults to having Zombie Fortress mode on always by default. If you want it to occur on every map, create a config file.
- Game will only be in Zombie Fortress mode by default if the map name starts with "zf_", "zf2_", "ze_" or "zsf_".
- If zombie player dies without using rage once, tell them to use it.
- Zombies using rage now get a 5 second speed boost (like in Zombie Fortress Redux)
- Add +2 rocket ammo for a solider when they kill a zombie.
- Add +2 pipe ammo for a demoman when they kill a zombie.
- Add +2 huntsman ammo / +5 sniper ammo for a sniper when they kill a zombie.
- Pyro now only has 100 flamethrower ammo like Zombie Fortress Redux.
- Add +15 flamethrower ammo for a pyro when they kill a zombie.
- Halve cost of pyro compression blast.
- Zombie hording now works like in original mod. Zombies sticking together will get health regen and crit bonuses.
- Zombies have resting, hunger and frenzied states like in original mod. Zombies will spawn faster after killing a survivor and will spawn slower after survivors kill half the teams worth of zombies.
- Survivors get crit bonuses for each zombie they kill like in original mod.